### PR TITLE
Add CS generation code, support for peripheral names and a touch of file/class renaming

### DIFF
--- a/luna_soc/gateware/wishbone/__init__.py
+++ b/luna_soc/gateware/wishbone/__init__.py
@@ -4,6 +4,6 @@
 # Copyright (c) 2023 Great Scott Gadgets <info@greatscottgadgets.com>
 # SPDX-License-Identifier: BSD-3-Clause
 
-from .memory import *
-from .qspi   import *
-from .sram   import *
+from .memory    import *
+from .spiflash  import *
+from .sram      import *

--- a/luna_soc/gateware/wishbone/spiflash/__init__.py
+++ b/luna_soc/gateware/wishbone/spiflash/__init__.py
@@ -10,8 +10,8 @@ from amaranth               import Elaboratable, Module
 from amaranth.lib.wiring    import connect
 
 from .port                  import SPIControlPortCDC, SPIControlPortCrossbar
-from .master                import SPIFlashMaster
 from .mmap                  import SPIFlashMemoryMap
+from .controller            import SPIController
 from .phy                   import SPIPHYController, ECP5ConfigurationFlashInterface
 
 __all__ = ["ECP5ConfigurationFlashInterface", "SPIPHYController", "SPIFlashPeripheral"]
@@ -20,29 +20,29 @@ __all__ = ["ECP5ConfigurationFlashInterface", "SPIPHYController", "SPIFlashPerip
 class SPIFlashPeripheral(Elaboratable):
     """SPI Flash peripheral main module.
 
-    This class provides a wrapper that can instantiate both ``SPIFlashMaster`` and
+    This class provides a wrapper that can instantiate both ``SPIController`` and
     ``SPIFlashMemoryMap`` and connect them to the PHY.
 
     Both options share access to the PHY using a crossbar.
     Also, performs CDC if a different clock is used in the PHY.
     """
-    def __init__(self, phy, *, data_width=32, granularity=8, with_master=True, master_name=None, with_mmap=True,
-        mmap_size=None, mmap_name=None, mmap_byteorder="little", domain="sync"):
+    def __init__(self, phy, *, data_width=32, granularity=8, with_controller=True, controller_name=None,
+                 with_mmap=True, mmap_size=None, mmap_name=None, mmap_byteorder="little", domain="sync"):
 
         self._domain    = domain
         self.data_width = data_width
         self.phy        = phy
         self.cores      = []
 
-        if with_master:
-            self.spi_master = SPIFlashMaster(
+        if with_controller:
+            self.spi_controller = SPIController(
                 data_width=data_width,
                 granularity=granularity,
-                name=master_name,
+                name=controller_name,
                 domain=domain,
             )
-            self.master = self.spi_master.bus
-            self.cores.append(self.spi_master)
+            self.csr = self.spi_controller.bus
+            self.cores.append(self.spi_controller)
 
         if with_mmap:
             self.spi_mmap = SPIFlashMemoryMap(
@@ -74,7 +74,7 @@ class SPIFlashPeripheral(Elaboratable):
             for i, core in enumerate(self.cores):
                 connect(m, core, crossbar.get_port(i))
 
-            phy_controller = crossbar.master
+            phy_controller = crossbar.controller
         else:
             phy_controller = self.cores[0]
 

--- a/luna_soc/gateware/wishbone/spiflash/controller.py
+++ b/luna_soc/gateware/wishbone/spiflash/controller.py
@@ -16,10 +16,10 @@ from ...vendor.lambdasoc.periph         import Peripheral
 from .port                              import SPIControlPort
 
 
-class SPIFlashMaster(Peripheral, wiring.Component):
-    """Wishbone generic SPI Flash master.
+class SPIController(Peripheral, wiring.Component):
+    """Wishbone generic SPI Flash Controller interface.
 
-    Provides a generic SPI master that can be controlled using CSRs.
+    Provides a generic SPI Controller that can be interfaced using CSRs.
     Supports multiple access modes with the help of ``width`` and ``mask`` registers which
     can be used to configure the PHY into any supported SDR mode (single/dual/quad/octal).
     """

--- a/luna_soc/gateware/wishbone/spiflash/master.py
+++ b/luna_soc/gateware/wishbone/spiflash/master.py
@@ -6,7 +6,7 @@
 
 # Based on code from LiteSPI
 
-from amaranth                           import Module, DomainRenamer
+from amaranth                           import Module, DomainRenamer, Signal
 from amaranth.lib                       import wiring
 from amaranth.lib.fifo                  import SyncFIFO
 from amaranth.lib.data                  import StructLayout, View
@@ -20,7 +20,7 @@ class SPIFlashMaster(Peripheral, wiring.Component):
     """Wishbone generic SPI Flash master.
 
     Provides a generic SPI master that can be controlled using CSRs.
-    Supports multiple access modes with the help of ``width`` and ``mask`` registers which 
+    Supports multiple access modes with the help of ``width`` and ``mask`` registers which
     can be used to configure the PHY into any supported SDR mode (single/dual/quad/octal).
     """
     def __init__(self, *, data_width=32, granularity=8, rx_depth=16, tx_depth=16, name=None, domain="sync"):
@@ -74,6 +74,20 @@ class SPIFlashMaster(Peripheral, wiring.Component):
             with m.If(reg.w_stb):
                 m.d.sync += reg.r_data.eq(reg.w_data)
 
+        # Chip select generation.
+        cs = Signal()
+        with m.FSM():
+            with m.State("RISE"):
+                # Enable chip select when the CSR is set to 1 and the TX FIFO contains something.
+                m.d.comb += cs.eq(tx_fifo.r_rdy)
+                with m.If(cs == 1):
+                    m.next = "FALL"
+            with m.State("FALL"):
+                # Only disable chip select after the current TX FIFO is emptied.
+                m.d.comb += cs.eq(self._cs.r_data | tx_fifo.r_rdy)
+                with m.If(cs == 0):
+                    m.next = "RISE"
+
         # Connect FIFOs to PHY streams.
         tx_fifo_payload = View(self.tx_fifo_layout, tx_fifo.w_data)
         m.d.comb += [
@@ -83,9 +97,9 @@ class SPIFlashMaster(Peripheral, wiring.Component):
             tx_fifo_payload.width   .eq(self._phy_width.r_data),
             tx_fifo_payload.mask    .eq(self._phy_mask.r_data),
             tx_fifo.w_en            .eq(self._rxtx.w_stb),
-            
+
             # SPI chip select.
-            self.cs                 .eq(self._cs.r_data),
+            self.cs                 .eq(cs),
 
             # TX FIFO to SPI PHY (PICO).
             self.source.payload     .eq(tx_fifo.r_data),

--- a/luna_soc/gateware/wishbone/spiflash/master.py
+++ b/luna_soc/gateware/wishbone/spiflash/master.py
@@ -25,7 +25,7 @@ class SPIFlashMaster(Peripheral, wiring.Component):
     """
     def __init__(self, *, data_width=32, granularity=8, rx_depth=16, tx_depth=16, name=None, domain="sync"):
         wiring.Component.__init__(self, SPIControlPort(data_width))
-        Peripheral.__init__(self)
+        Peripheral.__init__(self, name=name)
 
         self._domain   = domain
 

--- a/luna_soc/gateware/wishbone/spiflash/port.py
+++ b/luna_soc/gateware/wishbone/spiflash/port.py
@@ -103,7 +103,7 @@ class SPIControlPortCrossbar(wiring.Component):
         self._num_ports = num_ports
 
         super().__init__(dict(
-            master=Out(SPIControlPort(data_width)),
+            controller=Out(SPIControlPort(data_width)),
             **{f"slave{i}": In(SPIControlPort(data_width)) for i in range(num_ports)}
         ))
 
@@ -121,7 +121,7 @@ class SPIControlPortCrossbar(wiring.Component):
         with m.Switch(rr.grant):
             for i in range(self._num_ports):
                 with m.Case(i):
-                    connect(m, wiring.flipped(self.get_port(i)), wiring.flipped(self.master))
+                    connect(m, wiring.flipped(self.get_port(i)), wiring.flipped(self.controller))
                     m.d.comb += grant_update.eq(~rr.valid | ~rr.requests[i])
 
         return m


### PR DESCRIPTION
* add the cs chip selection generation code from yesterday
* add support for passing a peripheral name for the csr master interface
* rename `master` to `controller`
  - `spiflash/master.py` becomes `spiflash/controller.py` 
  - rename `SPIFlashMaster` to `SPIController`

  
Usage:
  
  ```rust
        # ... add a spi flash peripheral ...
        self.spi0_bus = ECP5ConfigurationFlashInterface(bus=self.qspi0_pins)
        self.spi0_phy = SPIPHYController(pads=self.spi0_bus, domain="usb", divisor=0)
        self.spi0     = SPIFlashPeripheral(
            phy=self.spi0_phy,
            with_controller=True,
            controller_name="spi0",
            with_mmap=True,
            mmap_size=spi0_flash_size,
            mmap_name="spiflash",
            domain="usb",
        )
        self.soc.add_peripheral(self.spi0, addr=spi0_flash_addr)
        self.soc.add_peripheral(
            self.spi0.spi_controller,
            addr=spi0_csr_addr,
            as_submodule=False,
        )
  ```